### PR TITLE
Added handleDestroy method to child component

### DIFF
--- a/src/connectModal.js
+++ b/src/connectModal.js
@@ -72,6 +72,10 @@ export default function connectModal({ name, resolve, destroyOnHide = true }) {
       handleHide = () => {
         this.props.hide(name)
       };
+    
+      handleDestroy = () => {
+        this.props.destroy(name)
+      };
 
       render() {
         const { show } = this.state
@@ -85,6 +89,7 @@ export default function connectModal({ name, resolve, destroyOnHide = true }) {
             {...modal.props}
             show={show}
             handleHide={this.handleHide}
+            handleDestroy={this.handleDestroy}
           />
         )
       }


### PR DESCRIPTION
Added handleDestroy method, for ability to destroy modal not only on hide, but manualy (for example after animation ends).