### PR TITLE
react 15.5 support with prop-types dependency

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "antd": "^1.3.2",
+    "prop-types": "^15.5.10",
     "react": "^15.1.0",
     "react-bootstrap": "^0.30.8",
     "react-dom": "^15.1.0"

--- a/example/src/containers/AntdModal.js
+++ b/example/src/containers/AntdModal.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { Modal } from 'antd'
 import { connectModal } from 'redux-modal'
 

--- a/example/src/containers/BootstrapModal.js
+++ b/example/src/containers/BootstrapModal.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { Button, Modal } from 'react-bootstrap'
 import { connectModal } from 'redux-modal'
 

--- a/example/src/containers/DynamicModal.js
+++ b/example/src/containers/DynamicModal.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { Button, Modal } from 'react-bootstrap'
 import { connectModal } from 'redux-modal'
 

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1501,7 +1501,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -2098,6 +2098,13 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types@^15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
 
 prop-types@^15.5.6, prop-types@^15.5.7, prop-types@~15.5.7:
   version "15.5.8"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "rimraf": "^2.5.0"
   },
   "dependencies": {
-    "hoist-non-react-statics": "^1.0.3"
+    "hoist-non-react-statics": "^1.0.3",
+    "prop-types": "^15.5.10"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",

--- a/src/connectModal.js
+++ b/src/connectModal.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import hoistStatics from 'hoist-non-react-statics'
@@ -72,7 +73,7 @@ export default function connectModal({ name, resolve, destroyOnHide = true }) {
       handleHide = () => {
         this.props.hide(name)
       };
-    
+
       handleDestroy = () => {
         this.props.destroy(name)
       };

--- a/test/connectModal.spec.js
+++ b/test/connectModal.spec.js
@@ -1,6 +1,7 @@
 import expect, { createSpy } from 'expect'
 import { mount } from 'enzyme'
-import React, { Children, Component, PropTypes } from 'react'
+import React, { Children, Component } from 'react'
+import PropTypes from 'prop-types'
 import { createStore, combineReducers } from 'redux'
 import connectModal from '../src/connectModal'
 import reducer from '../src/reducer'


### PR DESCRIPTION
resolves React 15.5 warning against using PropTypes from React directly

* updates lib to use 'prop-types'
* updates tests to use 'prop-types'
* updates example to use 'prop-types'

I did not update example to react 15.5 to keep pr small but can if desired.