### PR TITLE
moved @types/react to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,11 +57,11 @@
     "rimraf": "^2.5.0"
   },
   "dependencies": {
-    "@types/react": "^15.6.0",
     "hoist-non-react-statics": "^1.0.3",
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {
+    "@types/react": "^15.6.0",
     "react": "^0.14.0 || ^15.0.0",
     "react-redux": "^4.0.0 || ^5.0.0",
     "redux": "^3.0.0"


### PR DESCRIPTION
Moving `@types/react` to `peerDependencies` fixes a problem caused by duplicate typings in the `node_modules` folder:

```
Error at node_modules\redux-modal\node_modules\@types\React\index.d.ts:3580:13: Subsequent variable declarations must have the same type.  Variable 'text' must be of type 'SVGProps<SVGTextElement>', but here has type 'SVGProps<SVGTextElement>'.
Error at node_modules\redux-modal\node_modules\@types\React\index.d.ts:3581:13: Subsequent variable declarations must have the same type.  Variable 'textPath' must be of type 'SVGProps<SVGTextPathElement>', but here has type 'SVGProps<SVGTextPathElement>'.
Error at node_modules\redux-modal\node_modules\@types\React\index.d.ts:3582:13: Subsequent variable declarations must have the same type.  Variable 'tspan' must be of type 'SVGProps<SVGTSpanElement>', but here has type 'SVGProps<SVGTSpanElement>'.
Error at node_modules\redux-modal\node_modules\@types\React\index.d.ts:3583:13: Subsequent variable declarations must have the same type.  Variable 'use' must be of type 'SVGProps<SVGUseElement>', but here has type 'SVGProps<SVGUseElement>'.
Error at node_modules\redux-modal\node_modules\@types\React\index.d.ts:3584:13: Subsequent variable declarations must have the same type.  Variable 'view' must be of type 'SVGProps<SVGViewElement>', but here has type 'SVGProps<SVGViewElement>'.
```