### PR TITLE
Allow modal state to be mounted elsewhere

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -10,18 +10,23 @@ Connect a modal component to redux store.
   * `name`(String)(Require) The modal name.
   * `resolve`(Function) Things you want to resolve before show your modal, if return a promise, the modal will show after the promise resolved.
   * `destroyOnHide`(Bool) Whether destroy the modal state and umount the modal after hide, default is true.
+  * `getModalState`(Function) A function that takes the entire Redux state and returns the state slice which corresponds to where the redux-modal reducer was mounted. Defaults to assuming that the reducer is mounted under the 'modal' key.
 
 ### Returns
 
 A React component class that injects modal state and `handleHide` action creator into your modal component.
 
-### Example
+### Examples
 
 ```javascript
 export default connectModal({ name: 'myModal' })(MyModal)
 ```
-
 It will pass the modal state and a `handleHide` and `handleDestroy` action creator as props to your modal component.
+
+If you mounted your modal reducer at some other location such as `modals` instead of `modal` use the `getModalState` config
+```javascript
+export default connectModal({ name: 'myModal', getModalState: (state) => state.modals })(MyModal)
+```
 
 ## reducer
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,13 @@ interface IModalConfig {
    */
   resolve?: () => any,
   /**
+   * A function that takes the entire Redux state and returns the state slice which
+   * corresponds to where the redux-modal reducer was mounted. Defaults to assuming
+   * that the reducer is mounted under the 'modal' key.
+   * @param {function} getModalState
+   */
+  getModalState?: () => any,
+  /**
    * Weather destroy the modal state and umount the modal after hide, default is true
    * @param {boolean} destroyOnHide
    */

--- a/src/connectModal.js
+++ b/src/connectModal.js
@@ -8,7 +8,12 @@ import { getDisplayName, isPromise, isUndefined } from "./utils";
 
 const INITIAL_MODAL_STATE = {};
 
-export default function connectModal({ name, resolve, destroyOnHide = true }) {
+export default function connectModal({
+  name,
+  getModalState = state => state.modal,
+  resolve,
+  destroyOnHide = true
+}) {
   return WrappedComponent => {
     class ConnectModal extends Component {
       static displayName = `ConnectModal(${getDisplayName(WrappedComponent)})`;
@@ -102,7 +107,7 @@ export default function connectModal({ name, resolve, destroyOnHide = true }) {
 
     return connect(
       state => ({
-        modal: state.modal[name] || INITIAL_MODAL_STATE
+        modal: getModalState(state)[name] || INITIAL_MODAL_STATE
       }),
       dispatch => ({ ...bindActionCreators({ hide, destroy }, dispatch) })
     )(hoistStatics(ConnectModal, WrappedComponent));

--- a/test/connectModal.spec.js
+++ b/test/connectModal.spec.js
@@ -91,6 +91,27 @@ describe("connectModal", () => {
     expect(wrapper.html()).toEqual(null);
   });
 
+  it("can mount modal reducer to a custom location in state", () => {
+    const finalReducer = combineReducers({ customModals: reducer });
+    const store = createStore(finalReducer);
+    WrappedMyModal = connectModal({
+      name: "myModal",
+      getModalState: state => state.customModals
+    })(MyModal);
+
+    const wrapper = mount(
+      <ProviderMock store={store}>
+        <WrappedMyModal />
+      </ProviderMock>
+    );
+
+    expect(wrapper.html()).toEqual(null);
+
+    store.dispatch(show("myModal"));
+
+    expect(wrapper.find(MyModal).length).toEqual(1);
+  });
+
   it("destroy modal state before unmount", () => {
     const mockReducer = jest.fn(() => ({}));
     const finalReducer = combineReducers({ modal: mockReducer });


### PR DESCRIPTION
similar to how redux-form lets you mount reducer elsewhere
connectModal({ name: 'myModal', getModalState: (state) => state.myCustomModalState })

also useful if your root combineReducers is immutable, you can use
getModalState: (state) => state.get('modal')