### PR TITLE
added the state parameter to the getModalSTate function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ interface IModalConfig {
    * that the reducer is mounted under the 'modal' key.
    * @param {function} getModalState
    */
-  getModalState?: () => any,
+  getModalState?: (state: any) => any,
   /**
    * Weather destroy the modal state and umount the modal after hide, default is true
    * @param {boolean} destroyOnHide


### PR DESCRIPTION
otherwise was getting: 

```
TS2345: Argument of type '{ name: string; getModalState: (state: any) => any; }' is not assignable to parameter of type 'IModalConfig'.
  Types of property 'getModalState' are incompatible.
    Type '(state: any) => any' is not assignable to type '(() => any) | undefined'.
      Type '(state: any) => any' is not assignable to type '() => any'.
```

Thanks for this repo, it's awesome!