### PR TITLE
Add support redux 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "peerDependencies": {
     "react": "^0.14.0 || >=15.0.0",
     "react-redux": "^4.0.0 || ^5.0.0",
-    "redux": "^3.0.0"
+    "redux": "^3.0.0 || ^4.0.0"
   },
   "lint-staged": {
     "*.{js,json,css}": ["prettier --write", "git add"]


### PR DESCRIPTION
Redux 4 is out: https://github.com/reactjs/redux/releases/tag/v4.0.0

I think it's time to support it as well as redux 3.x.
I didn't notice any breaking changes. 💯 