### PR TITLE
Fixed typescript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,29 +13,29 @@ export type ModalState = any;
  * Signature for modal configuration
  */
 interface IModalConfig {
-    /**
-     * The name of the modal
-     * @param {string} name
-     */
-    name: string;
-    /**
-     * Things you want to resolve before show your modal,
-     * if return a promise, the modal will show after the promise resolved
-     * @param {function} resolve
-     */
-    resolve?: () => any;
-    /**
-     * A function that takes the entire Redux state and returns the state slice which
-     * corresponds to where the redux-modal reducer was mounted. Defaults to assuming
-     * that the reducer is mounted under the 'modal' key.
-     * @param {function} getModalState
-     */
-    getModalState?: (state: any) => ModalState;
-    /**
-     * Weather destroy the modal state and umount the modal after hide, default is true
-     * @param {boolean} destroyOnHide
-     */
-    destroyOnHide?: boolean;
+  /**
+   * The name of the modal
+   * @param {string} name
+   */
+  name: string;
+  /**
+   * Things you want to resolve before show your modal,
+   * if return a promise, the modal will show after the promise resolved
+   * @param {function} resolve
+   */
+  resolve?: () => any;
+  /**
+   * A function that takes the entire Redux state and returns the state slice which
+   * corresponds to where the redux-modal reducer was mounted. Defaults to assuming
+   * that the reducer is mounted under the 'modal' key.
+   * @param {function} getModalState
+   */
+  getModalState?: (state: any) => ModalState;
+  /**
+   * Weather destroy the modal state and umount the modal after hide, default is true
+   * @param {boolean} destroyOnHide
+   */
+  destroyOnHide?: boolean;
 }
 
 /**
@@ -73,25 +73,25 @@ export function reducer(state: ModalState, action: Action): ModalState;
  * decorator.
  */
 export interface IModalInjectedProps {
-    /**
-     * Boolean flag indicating whether the modal is showing or not
-     *
-     * @type {boolean}
-     * @memberof IModalInjectedProps
-     */
-    show: boolean;
-    /**
-     * Function that hides the component when called
-     *
-     * @memberof IModalInjectedProps
-     */
-    handleHide: () => void;
+  /**
+   * Boolean flag indicating whether the modal is showing or not
+   *
+   * @type {boolean}
+   * @memberof IModalInjectedProps
+   */
+  show: boolean;
+  /**
+   * Function that hides the component when called
+   *
+   * @memberof IModalInjectedProps
+   */
+  handleHide: () => void;
 }
 
 interface InjectedWrapperComponent {
-    <P extends IModalInjectedProps>(
-        component: ComponentType<P>
-    ): ComponentClass;
+  <P extends IModalInjectedProps>(
+      component: ComponentType<P>
+  ): ComponentClass;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,14 @@
 /// <reference types="react" />
+import { AnyAction } from 'redux';
 
 type Component<T> = React.Component<T>;
 type ComponentClass = React.ComponentClass;
 type StatelessComponent<T> = React.StatelessComponent<T>;
+
+/**
+ * ModalState model, currently {any}
+ */
+export type ModalState = any;
 
 /**
  * Signature for modal configuration
@@ -25,7 +31,7 @@ interface IModalConfig {
    * that the reducer is mounted under the 'modal' key.
    * @param {function} getModalState
    */
-  getModalState?: (state: any) => any,
+  getModalState?: (state: any) => ModalState,
   /**
    * Weather destroy the modal state and umount the modal after hide, default is true
    * @param {boolean} destroyOnHide
@@ -36,11 +42,7 @@ interface IModalConfig {
 /**
  * Signature for modal action
  */
-interface IModalAction {
-  /**
-   * Redux type property
-   */
-  type: string;
+interface IModalAction extends AnyAction {
   /**
    * Payload to update state
    */
@@ -95,11 +97,11 @@ export function destroy(modal: string): IShowAction;
 
 /**
  * The modal reducer. Should be given to mounted to your Redux state at modal
- * @param {any} state Previous state
+ * @param {ModalState} state Previous state
  * @param {IShowAction} action Action describing changes in the modal state
- * @return {any} The new state
+ * @return {ModalState} The new state
  */
-export function reducer(state: any, action: IShowAction): any;
+export function reducer(state: ModalState, action: IShowAction): ModalState;
 
 /**
  * Interface specification for properties which are injected by the `connectModal`

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="react" />
 import { Action } from "redux";
 
-type ComponentClass = React.ComponentClass;
+type ComponentClass<T> = React.ComponentClass<T>;
 type ComponentType<T> = React.ComponentType<T>;
 
 /**
@@ -89,9 +89,7 @@ export interface IModalInjectedProps {
 }
 
 interface InjectedWrapperComponent {
-    <P extends IModalInjectedProps>(
-        component: ComponentType<P>
-    ): ComponentClass;
+    <P extends IModalInjectedProps>(component: ComponentType<P>): ComponentClass<Exclude<P, IModalInjectedProps>>;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="react" />
 import { Action } from "redux";
 
-type ComponentClass<T> = React.ComponentClass<T>;
+type ComponentClass = React.ComponentClass;
 type ComponentType<T> = React.ComponentType<T>;
 
 /**
@@ -89,7 +89,9 @@ export interface IModalInjectedProps {
 }
 
 interface InjectedWrapperComponent {
-    <P extends IModalInjectedProps>(component: ComponentType<P>): ComponentClass<Exclude<P, IModalInjectedProps>>;
+    <P extends IModalInjectedProps>(
+        component: ComponentType<P>
+    ): ComponentClass;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,8 @@
 /// <reference types="react" />
-import { AnyAction } from 'redux';
+import { Action } from "redux";
 
-type Component<T> = React.Component<T>;
 type ComponentClass = React.ComponentClass;
-type StatelessComponent<T> = React.StatelessComponent<T>;
+type ComponentType<T> = React.ComponentType<T>;
 
 /**
  * ModalState model, currently {any}
@@ -14,63 +13,29 @@ export type ModalState = any;
  * Signature for modal configuration
  */
 interface IModalConfig {
-  /**
-   * The name of the modal
-   * @param {string} name
-   */
-  name: string,
-  /**
-   * Things you want to resolve before show your modal,
-   * if return a promise, the modal will show after the promise resolved
-   * @param {function} resolve
-   */
-  resolve?: () => any,
-  /**
-   * A function that takes the entire Redux state and returns the state slice which
-   * corresponds to where the redux-modal reducer was mounted. Defaults to assuming
-   * that the reducer is mounted under the 'modal' key.
-   * @param {function} getModalState
-   */
-  getModalState?: (state: any) => ModalState,
-  /**
-   * Weather destroy the modal state and umount the modal after hide, default is true
-   * @param {boolean} destroyOnHide
-   */
-  destroyOnHide?: boolean
-}
-
-/**
- * Signature for modal action
- */
-interface IModalAction extends AnyAction {
-  /**
-   * Payload to update state
-   */
-  payload: {
     /**
      * The name of the modal
+     * @param {string} name
      */
-    modal: string
-  };
-}
-
-/**
- * Signature for the show modal action
- */
-interface IShowAction extends IModalAction {
-  /**
-   * Payload to update state
-   */
-  payload: {
+    name: string;
     /**
-     * The name of the modal
+     * Things you want to resolve before show your modal,
+     * if return a promise, the modal will show after the promise resolved
+     * @param {function} resolve
      */
-    modal: string,
+    resolve?: () => any;
     /**
-     * Props to pass to component
+     * A function that takes the entire Redux state and returns the state slice which
+     * corresponds to where the redux-modal reducer was mounted. Defaults to assuming
+     * that the reducer is mounted under the 'modal' key.
+     * @param {function} getModalState
      */
-    props: any
-  };
+    getModalState?: (state: any) => ModalState;
+    /**
+     * Weather destroy the modal state and umount the modal after hide, default is true
+     * @param {boolean} destroyOnHide
+     */
+    destroyOnHide?: boolean;
 }
 
 /**
@@ -79,21 +44,21 @@ interface IShowAction extends IModalAction {
  * @param {any} props Props pass to your modal
  * @return {IShowAction}
  */
-export function show(modal: string, props: any): IShowAction;
+export function show(modal: string, props: any): Action;
 
 /**
  * The hide modal action creator
  * @param {string} modal The name of the modal to hide
  * @return {IShowAction}
  */
-export function hide(modal: string): IShowAction;
+export function hide(modal: string): Action;
 
 /**
  * Removes a modal from state
  * @param {string} modal The name of the modal to delete
  * @return {IShowAction}
  */
-export function destroy(modal: string): IShowAction;
+export function destroy(modal: string): Action;
 
 /**
  * The modal reducer. Should be given to mounted to your Redux state at modal
@@ -101,30 +66,32 @@ export function destroy(modal: string): IShowAction;
  * @param {IShowAction} action Action describing changes in the modal state
  * @return {ModalState} The new state
  */
-export function reducer(state: ModalState, action: IShowAction): ModalState;
+export function reducer(state: ModalState, action: Action): ModalState;
 
 /**
  * Interface specification for properties which are injected by the `connectModal`
  * decorator.
  */
 export interface IModalInjectedProps {
-  /**
-   * Boolean flag indicating whether the modal is showing or not
-   *
-   * @type {boolean}
-   * @memberof IModalInjectedProps
-   */
-  show: boolean;
-  /**
-   * Function that hides the component when called
-   *
-   * @memberof IModalInjectedProps
-   */
-  handleHide: () => void;
+    /**
+     * Boolean flag indicating whether the modal is showing or not
+     *
+     * @type {boolean}
+     * @memberof IModalInjectedProps
+     */
+    show: boolean;
+    /**
+     * Function that hides the component when called
+     *
+     * @memberof IModalInjectedProps
+     */
+    handleHide: () => void;
 }
 
 interface InjectedWrapperComponent {
-  <P extends IModalInjectedProps>(component: Component<P> | StatelessComponent<P>): ComponentClass
+    <P extends IModalInjectedProps>(
+        component: ComponentType<P>
+    ): ComponentClass;
 }
 
 /**
@@ -133,4 +100,6 @@ interface InjectedWrapperComponent {
  * @return {Component} A React component class that injects modal state and
  * handleHide action creator into your modal component
  */
-export function connectModal<TOwnProps>(config: IModalConfig): InjectedWrapperComponent;
+export function connectModal<TOwnProps>(
+    config: IModalConfig
+): InjectedWrapperComponent;


### PR DESCRIPTION
I had to remove interfaces that were not exported either way - they were incompatible with newer Redux versions due to removed `payload` prop. I replaced them with plain `Action` from Redux.

Additionally I changed reducer's types to match the ones required by Redux, it did not work at all.