### PR TITLE
Generic is added to `show` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ export default combineReducers({
 })
 ```
 
-## show(name, props)
+## show(name, props) | show<T>(name, props: T)
 
 The show modal action creator.
 
@@ -70,6 +70,14 @@ The show modal action creator.
 
 * `name`(String) The name of modal to show.
 * `props`(Object) Props pass to your modal.
+
+### Example
+
+```javascript
+import { MyModalProps } from '...'
+
+show<MyModalProps>('modalName', {prop1: 'example'})
+```
 
 ## hide(name)
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,11 +1,11 @@
 import { SHOW, HIDE, DESTROY } from './actionTypes';
 
-export function show(modal: string, props = {}) {
+export function show<T = {}>(modal: string, props?: T) {
   return {
     type: SHOW,
     payload: {
       modal,
-      props,
+      props: props || {},
     },
   };
 }

--- a/test/connectModal.spec.tsx
+++ b/test/connectModal.spec.tsx
@@ -39,6 +39,10 @@ describe('connectModal', () => {
     WrappedMyModal = SampleModal;
   });
 
+  it('works correctly with generic', () => {
+    show<{ test: boolean }>('myModal', { test: true });
+  });
+
   it('render null at first mount', () => {
     const finalReducer = () => ({ modal: {} });
     const store = createStore(finalReducer);

--- a/test/connectModal.spec.tsx
+++ b/test/connectModal.spec.tsx
@@ -53,7 +53,7 @@ describe('connectModal', () => {
       </Provider>
     );
 
-    expect(wrapper.html()).toEqual('');
+    expect(wrapper.html()).toEqual(null);
   });
 
   it('mount modal after dispatch show action', () => {
@@ -66,7 +66,7 @@ describe('connectModal', () => {
       </Provider>
     );
 
-    expect(wrapper.html()).toEqual('');
+    expect(wrapper.html()).toEqual(null);
 
     store.dispatch(show('myModal'));
     wrapper.update();
@@ -90,7 +90,7 @@ describe('connectModal', () => {
     store.dispatch(show('myModal'));
     store.dispatch(hide('myModal'));
 
-    expect(wrapper.html()).toEqual('');
+    expect(wrapper.html()).toEqual(null);
   });
 
   it('can mount modal reducer to a custom location in state', () => {
@@ -107,7 +107,7 @@ describe('connectModal', () => {
       </Provider>
     );
 
-    expect(wrapper.html()).toEqual('');
+    expect(wrapper.html()).toEqual(null);
 
     store.dispatch(show('myModal'));
     wrapper.update();


### PR DESCRIPTION
It allows to write such code:

```typescript
show<IProp>('modalName', {prop1: 'test'});
```

Instead of:

```typescript
const props: IProp = {prop1: 'test'};

show('modalName', props);
```